### PR TITLE
python(libs): add coverage to run codecov

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ cffi==1.16.0
 charset-normalizer==3.2.0
 click==8.1.7
 colorama==0.4.6
+coverage==7.3.2
 cryptography==41.0.4
 defusedxml==0.7.1
 Django==4.2.5


### PR DESCRIPTION
**O que foi feito?**
- Foi adicionada a lib **coverage** no `requirements.txt`