### PR TITLE
git(workflows): add postgres to test action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,31 +12,22 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
-    strategy:
-      max-parallel: 4
-      matrix:
-        python-version: ["3.11"]
 
     steps:
     - name: Checkout code
       uses: actions/checkout@v3
-
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python-version }}
-
-    - name: Install Dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
     
     - name: Config environment
-      run: make
+      run: make config
+    
+    - name: Start Docker Compose
+      run: docker compose up --build -d api
 
     - name: Run Tests
       run: |
-        cd api && coverage run manage.py test --settings=core.settings.dev && coverage report && coverage xml
+        docker exec django-api coverage run manage.py test
+        docker exec django-api coverage report
+        docker exec django-api coverage xml
 
     - name: Upload coverage reports to Codecov
       uses: codecov/codecov-action@v3
@@ -45,3 +36,7 @@ jobs:
           files: ./api/coverage.xml
           directory: ./api/coverage/reports/
           fail_ci_if_error: true
+    
+    - name: Stop Docker Compose
+      run: docker compose down -v
+  


### PR DESCRIPTION
**O que foi feito?**
- Foi adicionado o Docker Compose na inicialização dos testes, uma vez que é necessário um tipo único do PostgreSQL no banco de dados impossibilitando a utilização do SQLite para testes.