### PR TITLE
fix(api): remove non obligatory fields of users

### DIFF
--- a/api/users/backends/google.py
+++ b/api/users/backends/google.py
@@ -43,11 +43,13 @@ class GoogleOAuth2:
     def do_auth(user_data: dict) -> User | None:
         user, created = User.objects.get_or_create(
             first_name=user_data['given_name'],
-            last_name=user_data['family_name'],
+            email=user_data['email'],
         )
 
+        if user_data.get('family_name'):
+            user.last_name = user_data['family_name']
+
         if created:
-            user.email = user_data['email']
             user.save()
 
         return user

--- a/api/users/simplejwt/serializers.py
+++ b/api/users/simplejwt/serializers.py
@@ -12,7 +12,6 @@ class RefreshJWTSerializer(TokenRefreshSerializer):
         user = jwt_authentication.get_user(validated_token)
 
         data["first_name"] = str(user.first_name)
-        data["last_name"] = str(user.last_name)
         data["email"] = str(user.email)
 
         return data

--- a/api/users/tests.py
+++ b/api/users/tests.py
@@ -100,7 +100,6 @@ class UserSessionRegisterTests(APITestCase):
 
         created_user = users.get(email='user@email.com')
         self.assertEqual(created_user.first_name, 'given_name')
-        self.assertEqual(created_user.last_name, 'family_name')
         self.assertEqual(created_user.email, 'user@email.com')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
@@ -239,7 +238,6 @@ class UserSessionLoginTests(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data['first_name'], self.user.first_name)
-        self.assertEqual(response.data['last_name'], self.user.last_name)
         self.assertEqual(response.data['email'], self.user.email)
 
     def test_user_login_access_token(self) -> None:

--- a/api/users/views.py
+++ b/api/users/views.py
@@ -30,7 +30,6 @@ class Register(TokenObtainPairView):
                 'access': str(refresh.access_token),
                 'refresh': str(refresh),
                 'first_name': user.first_name,
-                'last_name': user.last_name,
                 'email': user.email,
             }
 


### PR DESCRIPTION
**O que foi feito?**
- O campo de `last_name` não é obrigatório nas informações da Google:
    - Foi definido esse campo como opcional no momento de criação do usuário