### PR TITLE
fix(Users): Corrige o erro de troca de nome de usuário.

### DIFF
--- a/api/users/backends/google.py
+++ b/api/users/backends/google.py
@@ -18,7 +18,7 @@ class GoogleOAuth2:
 
         try:
             response = Response()
-            response.status_code = status.HTTP_400_BAD_REQUEST 
+            response.status_code = status.HTTP_400_BAD_REQUEST
             response.headers = {'Content-Type': 'application/json'}
 
             if access_token != config('GOOGLE_OAUTH2_MOCK_TOKEN'):
@@ -43,13 +43,14 @@ class GoogleOAuth2:
     @staticmethod
     def do_auth(user_data: dict) -> User | None:
         user, created = User.objects.get_or_create(
-            first_name=user_data['given_name'],
-            email=user_data['email'],
-        )
+            email=user_data['email'])
+
+        if user_data.get('given_name'):
+            user.first_name = user_data['given_name']
 
         if user_data.get('family_name'):
             user.last_name = user_data['family_name']
-        
+
         if user_data.get('picture'):
             user.picture_url = user_data['picture']
 

--- a/api/users/backends/google.py
+++ b/api/users/backends/google.py
@@ -54,7 +54,6 @@ class GoogleOAuth2:
         if user_data.get('picture'):
             user.picture_url = user_data['picture']
 
-        if created:
-            user.save()
+        user.save()
 
         return user


### PR DESCRIPTION
## O que foi feito:
- Corrigido o erro quando o usuário troca de nome em sua conta do Google.
- A unica chave para criação/leitura de usuário agora e̍ o email
- O nome de usuário agora e̍ armazenado no banco de dados apenas após a leitura/criação do usuário.
- closes #99 