### PR TITLE
task(year/period): cria rota para retornar ano e período disponíveis no backend

### DIFF
--- a/api/api/tests/test_year_period_api.py
+++ b/api/api/tests/test_year_period_api.py
@@ -1,0 +1,16 @@
+from rest_framework.test import APITestCase
+from utils import sessions as sns
+
+
+class TestYearPeriodAPI(APITestCase):
+    def test_year_period(self):
+        response = self.client.get('/courses/year-period/')
+        year, period = sns.get_current_year_and_period()
+        next_year, next_period = sns.get_next_period()
+
+        expected_data = {
+            'year/period': [f'{year}/{period}', f'{next_year}/{next_period}'],
+        }
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data, expected_data)

--- a/api/api/urls.py
+++ b/api/api/urls.py
@@ -4,5 +4,6 @@ from api import views
 app_name = 'api'
 
 urlpatterns = [
-    path('', views.Search.as_view(), name="search")
+    path('', views.Search.as_view(), name="search"),
+    path('year-period/', views.YearPeriod.as_view(), name="year-period")
 ]

--- a/api/api/views.py
+++ b/api/api/views.py
@@ -1,6 +1,7 @@
 from utils.db_handler import filter_disciplines_by_name, filter_disciplines_by_code, filter_disciplines_by_year_and_period
 from rest_framework.decorators import APIView
 from .serializers import DisciplineSerializer
+from utils.sessions import get_current_year_and_period, get_next_period
 from rest_framework.response import Response
 from rest_framework.request import Request
 from rest_framework import status
@@ -15,7 +16,7 @@ class Search(APIView):
             string = string.strip()
 
         return string
-    
+
     def get(self, request: Request, *args, **kwargs) -> Response:
         name = self.treat_string(request.GET.get('search', None))
         year = self.treat_string(request.GET.get('year', None))
@@ -38,9 +39,21 @@ class Search(APIView):
 
             for term in name[1:]:
                 disciplines &= filter_disciplines_by_code(code=term)
-            
+
         filtered_disciplines = filter_disciplines_by_year_and_period(
             year=year, period=period, disciplines=disciplines)
         data = DisciplineSerializer(filtered_disciplines, many=True).data
 
         return Response(data[:MAXIMUM_RETURNED_DISCIPLINES], status.HTTP_200_OK)
+
+
+class YearPeriod(APIView):
+    def get(self, request: Request, *args, **kwargs) -> Response:
+        year, period = get_current_year_and_period()
+        next_year, next_period = get_next_period()
+
+        data = {
+            'year/period': [f'{year}/{period}', f'{next_year}/{next_period}'],
+        }
+
+        return Response(data, status.HTTP_200_OK)


### PR DESCRIPTION
**O que foi feito?**
- Foi criada uma nova view para rota de `/year-period`
- A view chama as funções de ano/período atuais e próximos a retorna as informações em uma lista
- O teste é simples, visto que a função de ano/período atuais e próximos já é testada em `test_date_utils.py`, podemos simplesmente verificar se o retorno da view está de acordo com o padrão solicitado