### PR TITLE
api(google): Ajusta erro urgente do Google OAuth

### DIFF
--- a/api/users/backends/google.py
+++ b/api/users/backends/google.py
@@ -42,8 +42,10 @@ class GoogleOAuth2:
 
     @staticmethod
     def do_auth(user_data: dict) -> User | None:
-        user, created = User.objects.get_or_create(
-            email=user_data['email'])
+        user, _ = User.objects.get_or_create(
+            email=user_data['email'],
+            username=user_data['email']
+        )
 
         if user_data.get('given_name'):
             user.first_name = user_data['given_name']


### PR DESCRIPTION
**O que foi feito?**
- Ajusta erro urgente ao realizar o cadastro através do Google (username não definido)