### PR TITLE
task(api/save): limita a quantidade de grades que o usuário pode salvar

### DIFF
--- a/api/api/tests/test_schedule_save.py
+++ b/api/api/tests/test_schedule_save.py
@@ -3,6 +3,8 @@ from rest_framework.reverse import reverse
 
 from rest_framework_simplejwt.serializers import TokenObtainPairSerializer
 
+from ..views.save_schedule import SCHEDULES_LIMIT, SCHEDULES_LIMIT_ERROR_MSG
+
 from utils import db_handler as dbh
 
 from api.serializers import ClassSerializerSchedule
@@ -43,6 +45,10 @@ class TestScheduleSaveAPI(APITestCase, ErrorRequestBodyScheduleSave):
             (['LUIS FILOMENO DE JESUS FERNANDES'], 'FGA - Sala I6', '46M34',
              ['Quarta-feira 10:00 às 11:50', 'Sexta-feira 10:00 às 11:50'],
              '2', [], self.disciplines['discipline_FGA0003_2023_2']),
+            (['RICARDO RAMOS FRAGELLI'], 'FGA - I9', '246M34',
+             ['Segunda-feira 10:00 às 11:50', 'Quarta-feira 10:00 às 11:50',
+              'Sexta-feira 10:00 às 11:50'], '24', [],
+             self.disciplines['discipline_MAT0025_2023_2']),
             (['EDSON ALVES DA COSTA JUNIOR'], 'FGA - I8', '35T23',
              ['Terça-feira 14:00 às 15:50', 'Quinta-feira 14:00 às 15:50'],
              '1', [], self.disciplines['discipline_FGA0003_2024_1']),
@@ -52,15 +58,28 @@ class TestScheduleSaveAPI(APITestCase, ErrorRequestBodyScheduleSave):
             (['RICARDO RAMOS FRAGELLI'], 'FGA - I9', '246M34',
              ['Segunda-feira 10:00 às 11:50', 'Quarta-feira 10:00 às 11:50',
               'Sexta-feira 10:00 às 11:50'], '24', [],
-             self.disciplines['discipline_MAT0025_2023_2']),
-            (['RICARDO RAMOS FRAGELLI'], 'FGA - I9', '246M34',
-             ['Segunda-feira 10:00 às 11:50', 'Quarta-feira 10:00 às 11:50',
-              'Sexta-feira 10:00 às 11:50'], '24', [],
              self.disciplines['discipline_MAT0025_2024_1']),
             (['RICARDO RAMOS FRAGELLI'], 'FGA - I7', '24M34 5T23',
              ['Segunda-feira 10:00 às 11:50', 'Quarta-feira 10:00 às 11:50',
               'Quinta-feira 14:00 às 15:50'], '25', [],
              self.disciplines['discipline_MAT0025_2024_1']),
+            (['VINICIUS RISPOLI'], 'FGA - I9', '245M34',
+             ['Segunda-feira 10:00 às 11:50', 'Quarta-feira 10:00 às 11:50',
+              'Quinta-Feira 10:00 às 11:50'], '24', [],
+             self.disciplines['discipline_MAT0025_2024_1']),
+            (['MATEUS VIEIRA ROCHA'], 'FGA - I9', '236M34',
+             ['Segunda-feira 10:00 às 11:50', 'Terça-feira 10:00 às 11:50',
+              'Sexta-feira 10:00 às 11:50'], '24', [],
+             self.disciplines['discipline_MAT0025_2024_1']),
+            (['LUIZA YOKO'], 'FGA - I9', '346M34',
+             ['Terça-feira 10:00 às 11:50', 'Quarta-feira 10:00 às 11:50',
+              'Sexta-feira 10:00 às 11:50'], '24', [],
+             self.disciplines['discipline_MAT0025_2024_1']),
+            (['LUIZA YOKO'], 'FGA - I9', '456M34',
+             ['Quarta-feira 10:00 às 11:50', 'Quinta-feira 10:00 às 11:50',
+              'Sexta-feira 10:00 às 11:50'], '24', [],
+             self.disciplines['discipline_MAT0025_2024_1']),
+
         ]
 
     def generate_schedule_structure(self, classes: list[Class]) -> list:
@@ -147,11 +166,9 @@ class TestScheduleSaveAPI(APITestCase, ErrorRequestBodyScheduleSave):
         """
         schedule = self.generate_schedule_structure([
             self.classes['class_0_2023_2'],
-            self.classes['class_4_2023_2']
+            self.classes['class_2_2023_2']
         ])
-
         response = self.make_post_request(schedule=schedule)
-
         self.assertEqual(len(self.user.schedules.all()), 1)
         self.assertEqual(response.status_code, 201)
 
@@ -206,7 +223,7 @@ class TestScheduleSaveAPI(APITestCase, ErrorRequestBodyScheduleSave):
         - Status code (400 BAD REQUEST)
         """
         schedule = self.generate_schedule_structure([
-            self.classes['class_2_2024_1'],
+            self.classes['class_3_2024_1'],
             self.classes['class_6_2024_1']
         ])
 
@@ -225,7 +242,7 @@ class TestScheduleSaveAPI(APITestCase, ErrorRequestBodyScheduleSave):
         """
         schedule = self.generate_schedule_structure([
             self.classes['class_0_2023_2'],
-            self.classes['class_4_2023_2']
+            self.classes['class_2_2023_2']
         ])
 
         response = self.make_post_request(auth=False, schedule=schedule)
@@ -241,10 +258,43 @@ class TestScheduleSaveAPI(APITestCase, ErrorRequestBodyScheduleSave):
         """
         schedule = self.generate_schedule_structure([
             self.classes['class_0_2023_2'],
-            self.classes['class_4_2023_2']
+            self.classes['class_2_2023_2']
         ])
 
         token = 'incorrect_token'
         response = self.make_post_request(auth=token, schedule=schedule)
 
         self.assertEqual(response.status_code, 403)
+
+    def test_save_limit_reached(self):
+        """
+        Testa o salvamento de uma grade horária quando o limite de grades horárias é atingido.
+        Salva todas as grades horárias possíveis e tenta salvar mais uma.
+
+        Tests:
+        - Status code (400 BAD REQUEST)
+        """
+
+        for i in range(3):
+            schedule = self.generate_schedule_structure([
+                self.classes[f'class_{i}_2023_2']
+            ])
+
+            response = self.make_post_request(schedule=schedule)
+            self.assertEqual(response.status_code, 201)
+
+        for i in range(3, SCHEDULES_LIMIT):
+            schedule = self.generate_schedule_structure([
+                self.classes[f'class_{i}_2024_1']
+            ])
+            response = self.make_post_request(schedule=schedule)
+            self.assertEqual(response.status_code, 201)
+
+        schedule = self.generate_schedule_structure([
+            self.classes[f'class_{SCHEDULES_LIMIT-1}_2024_1']
+        ])
+
+        response = self.make_post_request(schedule=schedule)
+        self.assertEqual(response.data.get('errors'),
+                         SCHEDULES_LIMIT_ERROR_MSG)
+        self.assertEqual(response.status_code, 400)

--- a/api/api/views/save_schedule.py
+++ b/api/api/views/save_schedule.py
@@ -12,6 +12,7 @@ from api.views.utils import handle_400_error
 from api import serializers
 
 SCHEDULES_LIMIT = 10
+SCHEDULES_LIMIT_ERROR_MSG = f"you have reached the limit of {SCHEDULES_LIMIT} schedules"
 
 
 class SaveSchedule():
@@ -26,7 +27,7 @@ class SaveSchedule():
     )
     def post(self, request: request.Request, *args, **kwargs) -> response.Response:
         if not check_permission_to_save(request.user):
-            return handle_400_error("you have reached the limit of schedules")
+            return handle_400_error(SCHEDULES_LIMIT_ERROR_MSG)
 
         classes = request.data
 

--- a/api/api/views/save_schedule.py
+++ b/api/api/views/save_schedule.py
@@ -11,6 +11,8 @@ from api.swagger import Errors
 from api.views.utils import handle_400_error
 from api import serializers
 
+SCHEDULES_LIMIT = 10
+
 
 class SaveSchedule():
     @swagger_auto_schema(
@@ -23,6 +25,9 @@ class SaveSchedule():
         }
     )
     def post(self, request: request.Request, *args, **kwargs) -> response.Response:
+        if not check_permission_to_save(request.user):
+            return handle_400_error("you have reached the limit of schedules")
+
         classes = request.data
 
         try:
@@ -204,3 +209,11 @@ def validate_received_schedule(classes_id: list[int]) -> list[Class]:
         raise ValueError("the classes are not compatible")
 
     return schedules[0]
+
+
+def check_permission_to_save(user) -> bool:
+    schedules = dbh.get_schedules(user)
+
+    if len(schedules) >= SCHEDULES_LIMIT:
+        return False
+    return True

--- a/api/api/views/views.py
+++ b/api/api/views/views.py
@@ -19,7 +19,7 @@ from api.models import Discipline
 from api.views.utils import handle_400_error
 
 
-MAXIMUM_RETURNED_DISCIPLINES = 8
+MAXIMUM_RETURNED_DISCIPLINES = 15
 ERROR_MESSAGE = "no valid argument found for 'search', 'year' or 'period'"
 MINIMUM_SEARCH_LENGTH = 4
 ERROR_MESSAGE_SEARCH_LENGTH = f"search must have at least {MINIMUM_SEARCH_LENGTH} characters"


### PR DESCRIPTION
**issue**
closes #155 

**O que foi feito? **
- Adicionado limite de grades que um usuário pode salvar. 
- Limite: 10
- Adicionados testes para validar essa funcionalidade.