### PR TITLE
devops(ci): faz deploy da documentação apenas quando há mudança na pasta

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'docs/**'
 
 permissions:
   contents: write


### PR DESCRIPTION
**O que foi feito?**
- O CI de deploy da documentação foi modificado para executar apenas quando houver mudança na pasta `/docs`