### PR TITLE
fix(popup): arruma do popup com muitas disciplinas

### DIFF
--- a/web/app/components/AsideSchedulePopUp/AsideSchedulePopUp.tsx
+++ b/web/app/components/AsideSchedulePopUp/AsideSchedulePopUp.tsx
@@ -42,7 +42,7 @@ function AsideSchedulePopUpJSX(props: AsideSchedulePopUpJSXPropsType) {
         <div className='flex justify-center'>
             <div
                 ref={props.divAddClassRef}
-                className={`flex flex-col justify-between items-center w-11/12 ${showPopUpContent ? 'py-5 h-5/6' : 'h-0'} transition-all duration-500 absolute bottom-0 rounded-t-[40px] bg-snow-secondary z-10`}
+                className={`fixed flex flex-col justify-between items-center w-11/12 ${showPopUpContent ? 'py-5 h-5/6' : 'h-0'} transition-all duration-500 bottom-0 rounded-t-[40px] bg-snow-secondary z-10`}
             >
                 {showPopUpContent &&
                     <section className='flex flex-col items-center gap-5 w-full h-full text-[#333333]'>


### PR DESCRIPTION
**O que foi corrigido?**
- Como o popup estava como `absolute` ao adicionar muitas disciplinas o mesmo subia e quebrava a experiência do usuário
- Assim houve a correção e o erro não acontece mais

**Erro:**

<img height="750px" src="https://github.com/unb-mds/2023-2-Squad11/assets/68292695/21f8816b-e404-420f-9906-a13798f7240f" />

